### PR TITLE
Timeline drag/click actions

### DIFF
--- a/include/TimeLineWidget.h
+++ b/include/TimeLineWidget.h
@@ -175,6 +175,10 @@ signals:
 
 
 public slots:
+	void updateLength(const int& bars)
+	{
+		m_length = TimePos(bars * TimePos::ticksPerBar());
+	};
 	void updatePosition( const TimePos & );
 	void updatePosition()
 	{
@@ -183,6 +187,8 @@ public slots:
 	void toggleAutoScroll( int _n );
 	void toggleLoopPoints( int _n );
 	void toggleBehaviourAtStop( int _n );
+
+	// TODO updateSnapSize
 
 
 protected:
@@ -194,6 +200,10 @@ protected:
 
 
 private:
+	void chooseMouseAction(QMouseEvent* event);
+	TimePos getPositionFromX(const int x) const;
+	void setLoopPoint(bool end, int x, bool unquantized=false);
+
 	static QPixmap * s_posMarkerPixmap;
 
 	QColor m_inactiveLoopColor;
@@ -221,28 +231,32 @@ private:
 	float m_snapSize;
 	Song::PlayPos & m_pos;
 	const TimePos & m_begin;
+	TimePos m_length = 0;
 	const Song::PlayModes m_mode;
 	TimePos m_loopPos[2];
+	TimePos m_oldLoopPos[2];
 
 	TimePos m_savedPos;
 
 
 	TextFloat * m_hint;
-	int m_initalXSelect;
+	int m_moveStartX = 0;
 
 
 	enum actions
 	{
 		NoAction,
+		Thresholded,
+		ShowContextMenu,
 		MovePositionMarker,
 		MoveLoopBegin,
 		MoveLoopEnd,
 		MoveLoopClosest,
 		DragLoop,
+		DrawLoop,
 		SelectSongTCO,
 	} m_action;
 
-	int m_moveXOff;
 
 
 signals:

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -841,6 +841,7 @@ void PianoRoll::setCurrentPattern( Pattern* newPattern )
 	if( hasValidPattern() )
 	{
 		m_pattern->instrumentTrack()->disconnect( this );
+		m_pattern->disconnect(this);
 	}
 
 	// force the song-editor to stop playing if it played pattern before
@@ -905,6 +906,11 @@ void PianoRoll::setCurrentPattern( Pattern* newPattern )
 
 	connect(m_pattern->instrumentTrack()->firstKeyModel(), SIGNAL(dataChanged()), this, SLOT(update()));
 	connect(m_pattern->instrumentTrack()->lastKeyModel(), SIGNAL(dataChanged()), this, SLOT(update()));
+
+	connect(m_pattern, &TrackContentObject::lengthChanged, m_timeLine, [this]
+	{
+		m_timeLine->updateLength(m_pattern->length().nextFullBar());
+	});
 
 	update();
 	emit currentPatternChanged();

--- a/src/gui/editors/SongEditor.cpp
+++ b/src/gui/editors/SongEditor.cpp
@@ -93,6 +93,7 @@ SongEditor::SongEditor( Song * song ) :
 			this, SLOT( selectRegionFromPixels( int, int ) ) );
 	connect( m_timeLine, SIGNAL( selectionFinished() ),
 			 this, SLOT( stopRubberBand() ) );
+	connect(m_song, SIGNAL(lengthChanged(int)), m_timeLine, SLOT(updateLength(int)));
 
 	m_positionLine = new PositionLine(this);
 	static_cast<QVBoxLayout *>( layout() )->insertWidget( 1, m_timeLine );


### PR DESCRIPTION
- ~All previous bindings are the same~ no mean select
- RMB *click* for context menu
- RMB *drag* to draw a loop
- Mid drag to move loop
- Context menu has "set start" and "set end"
- Setting end before start selects to start of song/pattern
- Setting start after end selects to end of song/pattern (thus the updateLength() code)

~Ugly thing: Actions that support ctrl for unqunatize may be started both in mousePressEvent and in mouseMoveEvent (drag threshold). This complicates how the helpful TextFloat is called. There are 3 solutions:~

1. ~Check and call TextFloat in both mousePressEvent and mouseMoveEvent.~
2. ~Only call in mouseMoveEvent. Display it all the time, even when ctrl is held (this was my solution).~
3. ~Only call in mouseMoveEvent. Close when ctrl is held and re-open when ctrl is released.~