### PR TITLE
Separate drag/click

### DIFF
--- a/include/TimeLineWidget.h
+++ b/include/TimeLineWidget.h
@@ -194,6 +194,7 @@ protected:
 
 
 private:
+	void chooseMouseAction(QMouseEvent* event);
 	TimePos getPositionFromX(const int x) const;
 	void setLoopPoint(bool end, int x, bool unquantized=false);
 
@@ -237,12 +238,14 @@ private:
 	enum actions
 	{
 		NoAction,
+		Thresholded,
 		MovePositionMarker,
 		MoveLoopBegin,
 		MoveLoopEnd,
 		MoveLoopClosest,
 		DragLoop,
 		SelectSongTCO,
+		ShowContextMenu
 	} m_action;
 
 

--- a/src/gui/TimeLineWidget.cpp
+++ b/src/gui/TimeLineWidget.cpp
@@ -454,6 +454,11 @@ void TimeLineWidget::chooseMouseAction(QMouseEvent* event)
 	auto type = event->type();
 
 	// TODO: Read these from a config
+	auto leftCtrlAction = SelectSongTCO;
+	auto rightCtrlAction = MoveLoopClosest;
+	auto leftShiftAction = MoveLoopBegin;
+	auto rightShiftAction = MoveLoopEnd;
+
 	// Unmodified LMB is reserved for playhead, unmodified RMB for context menu
 	// Shift or Ctrl modified press behavior is bound by the user
 	// Shift + Ctrl modifier is reserved for fine adjustment of Shift actions
@@ -469,13 +474,13 @@ void TimeLineWidget::chooseMouseAction(QMouseEvent* event)
 	{
 		if (buttons & Qt::LeftButton)
 		{
-			if (mods & Qt::ShiftModifier) { m_action = MoveLoopBegin; }
-			else if (mods & Qt::ControlModifier) { m_action = SelectSongTCO; }
+			if (mods & Qt::ShiftModifier) { m_action = leftShiftAction; }
+			else if (mods & Qt::ControlModifier) { m_action = leftCtrlAction; }
 		}
 		else if (buttons & Qt::RightButton)
 		{
-			if (mods & Qt::ShiftModifier) { m_action = MoveLoopEnd; }
-			else if (mods & Qt::ControlModifier) { m_action = MoveLoopClosest; }
+			if (mods & Qt::ShiftModifier) { m_action = rightShiftAction; }
+			else if (mods & Qt::ControlModifier) { m_action = rightCtrlAction; }
 		}
 	}
 	// If mouse has not moved
@@ -483,12 +488,12 @@ void TimeLineWidget::chooseMouseAction(QMouseEvent* event)
 	{
 		if (buttons & Qt::LeftButton)
 		{
-			if (mods & Qt::ShiftModifier) { m_action = MoveLoopBegin; }
+			if (mods & Qt::ShiftModifier) { m_action = leftShiftAction; }
 		}
 		else if (buttons & Qt::RightButton)
 		{
-			if (mods & Qt::ShiftModifier) { m_action = MoveLoopEnd; }
-			else if (mods & Qt::ControlModifier) { m_action = MoveLoopClosest; }
+			if (mods & Qt::ShiftModifier) { m_action = rightShiftAction; }
+			else if (mods & Qt::ControlModifier) { m_action = rightCtrlAction; }
 			else { m_action = ShowContextMenu; }
 		}
 	}

--- a/src/gui/TimeLineWidget.cpp
+++ b/src/gui/TimeLineWidget.cpp
@@ -335,8 +335,8 @@ void TimeLineWidget::mousePressEvent( QMouseEvent* event )
 	if (event->x() < m_xOffset || m_action != NoAction) { return; }
 	// Handles moving playhead
 	else if (button == Qt::LeftButton && mods == Qt::NoModifier) { m_action = MovePositionMarker; }
-	// Choose an action based on input event and user's bindings
-	else { chooseMouseAction(event); }
+	// Wait for drag or release
+	else { m_action = Thresholded; }
 
 	// Set initial position for actions that need it
 	m_initalXSelect = event->x();
@@ -464,13 +464,10 @@ void TimeLineWidget::chooseMouseAction(QMouseEvent* event)
 	// Shift + Ctrl modifier is reserved for fine adjustment of Shift actions
 	// TODO: Let MMB be bound
 
-	if (type == QEvent::MouseButtonPress)
-	{
-		// Wait for drag or release
-		m_action = Thresholded;
-	}
+	m_action = NoAction;
+
 	// If mouse has moved past threshold
-	else if (type == QEvent::MouseMove)
+	if (type == QEvent::MouseMove)
 	{
 		if (buttons & Qt::LeftButton)
 		{


### PR DESCRIPTION
This PR adds the functionality for different bindings of drag/click on timeline. Idk how far you want to go.

- Everything still works same way as before.
- Reworked binding logic, moved out of `mousePressEvent` to `chooseMouseAction`.
- Context menu called from `mouseReleaseEvent` - click only.