### PR TITLE
Loop move

### DIFF
--- a/include/TimeLineWidget.h
+++ b/include/TimeLineWidget.h
@@ -184,7 +184,6 @@ public slots:
 	void toggleLoopPoints( int _n );
 	void toggleBehaviourAtStop( int _n );
 
-
 protected:
 	void paintEvent( QPaintEvent * _pe ) override;
 	void mousePressEvent( QMouseEvent * _me ) override;
@@ -222,11 +221,12 @@ private:
 	int m_xOffset;
 	int m_posMarkerX;
 	float m_ppb;
-	float m_snapSize;
+	float m_snapSize; // TODO: updateSnapSize()
 	Song::PlayPos & m_pos;
 	const TimePos & m_begin;
 	const Song::PlayModes m_mode;
 	TimePos m_loopPos[2];
+	TimePos m_oldLoopPos[2];
 
 	TimePos m_savedPos;
 


### PR DESCRIPTION
Right drag to move loop.

Now here we go again: To unquantize, hold down Ctrl. As we discussed earlier having Ctrl+Shift as the unquantize combo may result in weird scenarios where the order of keypress matters. With this PR I've simply made it so `unquantized = modifiers() & ControlModifier`. The text float is also updated to say "Press Ctrl" instead of "Press Ctrl+Shift".

Based on #9. Just merge in numerical order and everything will be alright :heart_eyes: 